### PR TITLE
Expose Random in scenario

### DIFF
--- a/simulator/src/main/java/byzzbench/simulator/BaseScenario.java
+++ b/simulator/src/main/java/byzzbench/simulator/BaseScenario.java
@@ -73,8 +73,10 @@ public abstract class BaseScenario implements Scenario {
     protected ScenarioPredicate terminationCondition;
     /**
      * Pseudo-random number generator for the scenario.
+     * TODO: parameterize the seed
      */
-    Random rand;
+    @Getter
+    Random random = new Random(1L);
 
     /**
      * Creates a new scenario with the given unique identifier and scheduler.

--- a/simulator/src/main/java/byzzbench/simulator/Scenario.java
+++ b/simulator/src/main/java/byzzbench/simulator/Scenario.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.Serializable;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.Random;
 import java.util.SortedSet;
 
 /**
@@ -146,4 +147,11 @@ public interface Scenario extends Serializable {
      * @return True if the invariants hold, false otherwise.
      */
     boolean invariantsHold();
+
+    /**
+     * Get the random number generator for the scenario.
+     *
+     * @return The random number generator for the scenario.
+     */
+    Random getRandom();
 }


### PR DESCRIPTION
This adds a scenario-wide `Random` instance based on a seed.

This can be used to safely generate pseudorandom numbers that do not impact reproducibility of the scenarios.