### PR TITLE
fix(twins): enforce a single global per-round partition for all nodes

### DIFF
--- a/simulator/src/main/java/byzzbench/simulator/exploration_strategy/twins/TwinsExplorationStrategy.java
+++ b/simulator/src/main/java/byzzbench/simulator/exploration_strategy/twins/TwinsExplorationStrategy.java
@@ -4,13 +4,17 @@ import byzzbench.simulator.Scenario;
 import byzzbench.simulator.exploration_strategy.ExplorationStrategyParameters;
 import byzzbench.simulator.exploration_strategy.random.RandomExplorationStrategy;
 import byzzbench.simulator.nodes.Replica;
+import byzzbench.simulator.utils.StirlingNumberSecondKind;
 import lombok.Getter;
 import lombok.extern.java.Log;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
 
 /**
  * The Twins exploration_strategy from "Twins: BFT Systems Made Robust" by Shehar Bano,
@@ -39,7 +43,7 @@ public class TwinsExplorationStrategy extends RandomExplorationStrategy {
 
         this.scenarioData.put(scenario, scenarioParams);
 
-        // Get the IDs of the replicas
+        // Get the IDs of the replicas to compromise (turn into twins)
         List<String> replicaIds = scenario.getFaultyReplicaIds().stream().toList();
 
         if (replicaIds.size() < scenarioParams.getNumReplicas()) {
@@ -47,12 +51,57 @@ public class TwinsExplorationStrategy extends RandomExplorationStrategy {
         }
 
         replicaIds = replicaIds.subList(0, scenarioParams.getNumReplicas());
-        // Create the twins for each replica
-        for (int i = 0; i < scenarioParams.getNumReplicas(); i++) {
-            Replica replica = scenario.getReplicas().get(replicaIds.get(i));
+
+        // 1. Create the twin instances for each compromised replica and replace
+        //    the original in the node set with the multiplexing TwinsReplica.
+        for (String replicaId : replicaIds) {
+            Replica replica = scenario.getReplicas().get(replicaId);
             log.info("Creating " + scenarioParams.getNumTwinsPerReplica() + " twins for replica " + replica.getId());
-            scenario.getNodes().put(replica.getId(), new TwinsReplica(replica, scenarioParams.getNumTwinsPerReplica(), scenarioParams.getNumRounds()));
+            scenario.getNodes().put(replica.getId(), new TwinsReplica(replica, scenarioParams.getNumTwinsPerReplica()));
         }
+
+        // 2. Build the GLOBAL partition universe: honest replicas by their id,
+        //    twin instances by their internal addresses, so that a node and its
+        //    twin can be placed in different partitions.
+        List<String> universe = new ArrayList<>();
+        for (Replica replica : scenario.getReplicas().values()) {
+            if (replica instanceof TwinsReplica twin) {
+                universe.addAll(twin.getInternalIds());
+            } else {
+                universe.add(replica.getId());
+            }
+        }
+
+        // 3. Generate ONE global per-round partition schedule, shared by all
+        //    nodes. Partitions are sampled (using the scenario's seeded RNG, for
+        //    reproducibility) from all the ways of splitting the universe into
+        //    1, 2 or 3 parts.
+        List<List<List<String>>> options = new ArrayList<>();
+        options.addAll(StirlingNumberSecondKind.getPartitions(universe, 1));
+        options.addAll(StirlingNumberSecondKind.getPartitions(universe, 2));
+        options.addAll(StirlingNumberSecondKind.getPartitions(universe, 3));
+
+        Random rand = new Random(scenario.getRandom().nextLong());
+        Map<Long, List<List<String>>> roundPartitions = new TreeMap<>();
+        for (long round = 0; round < scenarioParams.getNumRounds(); round++) {
+            roundPartitions.put(round, options.get(rand.nextInt(options.size())));
+        }
+
+        // 4. Create the single global Twins transport and wire EVERY replica to
+        //    it (honest replicas and twin instances), so the same partition
+        //    schedule governs all links, including honest-to-honest ones.
+        TwinsTransport transport = new TwinsTransport(scenario, roundPartitions, universe);
+        for (Replica replica : scenario.getReplicas().values()) {
+            if (replica instanceof TwinsReplica twin) {
+                twin.setTwinsTransport(transport);
+                twin.setTransport(transport);
+                twin.getReplicas().forEach(instance -> instance.setTransport(transport));
+            } else {
+                replica.setTransport(transport);
+            }
+        }
+
+        roundPartitions.forEach((round, partitions) -> log.info("Round " + round + ": " + partitions));
     }
 
 }

--- a/simulator/src/main/java/byzzbench/simulator/exploration_strategy/twins/TwinsReplica.java
+++ b/simulator/src/main/java/byzzbench/simulator/exploration_strategy/twins/TwinsReplica.java
@@ -4,17 +4,24 @@ import byzzbench.simulator.exploration_strategy.byzzfuzz.MessageWithByzzFuzzRoun
 import byzzbench.simulator.nodes.Replica;
 import byzzbench.simulator.state.TotalOrderCommitLog;
 import byzzbench.simulator.transport.MessagePayload;
-import byzzbench.simulator.utils.StirlingNumberSecondKind;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.java.Log;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
+import java.util.Set;
 
 /**
  * A Twins {@link Replica} that emulates byzantine behavior
  * by switching between different replica instances behind the scenes.
+ * <p>
+ * Every instance shares the same external identity ({@link #getId()}); to the
+ * rest of the system the twins are indistinguishable from a single node. The
+ * per-round network partition that decides which instance(s) see a given message
+ * is a <b>global</b> schedule shared by all nodes, held by the
+ * {@link TwinsTransport} injected via {@link #setTwinsTransport(TwinsTransport)}.
  * <p>
  * See "Twins: BFT Systems Made Robust" by Shehar Bano, Alberto Sonnino,
  * Andrey Chursin, Dmitri Perelman, Zekun Li, Avery Ching and Dahlia Malkhi.
@@ -23,23 +30,26 @@ import java.util.Random;
 @Getter
 @Log
 public class TwinsReplica extends Replica {
-    private final TwinsTransport twinsTransport;
     /**
-     * The list of replicas that are part of this Twins replica.
+     * The shared, global Twins transport holding the per-round partitions.
+     * Injected by the {@link TwinsExplorationStrategy} once all twins exist.
+     */
+    @Setter
+    private TwinsTransport twinsTransport;
+
+    /**
+     * The list of replica instances that are part of this Twins replica.
      */
     private final ArrayList<Replica> replicas = new ArrayList<>();
-    Random rand;
 
     /**
      * Create a new Twins replica.
      *
-     * @param replica   the replica to clone
-     * @param numTwins  the number of twins to create
-     * @param numRounds the number of rounds to generate partitions for
+     * @param replica  the replica to clone
+     * @param numTwins the number of twin instances to create (>= 2)
      */
-    public TwinsReplica(Replica replica, int numTwins, int numRounds) {
+    public TwinsReplica(Replica replica, int numTwins) {
         super(replica.getId(), replica.getScenario(), new TotalOrderCommitLog());
-        this.rand = new Random(replica.getScenario().getRandom().nextLong());
 
         // Sanity check: must have at least 2 twins
         if (numTwins < 2) {
@@ -51,31 +61,13 @@ public class TwinsReplica extends Replica {
             throw new IllegalArgumentException("Cannot create Twins replica from another Twins replica");
         }
 
-        // create the twin copies
+        // create the twin copies (all sharing the same external identity)
         replicas.add(replica);
         for (int i = 1; i < numTwins; i++) {
             Replica twin = replica.getScenario().cloneReplica(replica);
             replicas.add(twin);
             twin.initialize();
         }
-
-        // Update the replicas to use a Twins transport
-        // Note: this must be done after the replicas are created and added to the list!
-        this.twinsTransport = new TwinsTransport(this);
-        this.replicas.forEach(r -> r.setTransport(this.twinsTransport));
-
-        // Create some round partitions.
-        List<String> nodeIds = new ArrayList<>(replica.getNodeIds().stream().filter(id -> !id.equals(this.getId())).toList());
-        nodeIds.addAll(getInternalIds());
-        List<List<List<String>>> options = StirlingNumberSecondKind.getPartitions(nodeIds, 1);
-        options.addAll(StirlingNumberSecondKind.getPartitions(nodeIds, 2));
-        options.addAll(StirlingNumberSecondKind.getPartitions(nodeIds, 3));
-        for (long i = 0; i < numRounds; i++) {
-            this.twinsTransport.getRoundPartitions().put(i, options.get(rand.nextInt(options.size())));
-        }
-
-        // print getRoundPartitions, one per line
-        this.twinsTransport.getRoundPartitions().forEach((k, v) -> log.info("Round " + k + ": " + v));
 
         // Mark ourselves as faulty
         this.markFaulty();
@@ -129,33 +121,43 @@ public class TwinsReplica extends Replica {
     }
 
     /**
-     * Get the internal replicas that should handle the given message.
+     * Get the internal replicas that should handle the given message, according
+     * to the global per-round partition: an instance handles the message only if
+     * it shares the sender's partition for that round.
      *
-     * @param sender  the sender of the message
+     * @param sender  the (external) id of the sender of the message
      * @param message the message to deliver
      * @return the list of internal replicas that should handle the message
      */
     public List<Replica> getInternalReplicasHandlingMessage(String sender, MessagePayload message) {
-        List<String> partition;
-        if (message instanceof MessageWithByzzFuzzRoundInfo messageWithByzzFuzzRoundInfo) {
-            // If the message has a round number, use the partition for that round
-            partition = this.twinsTransport.getReplicaRoundPartition(sender, messageWithByzzFuzzRoundInfo.getRound());
-        } else {
-            // Default to the default partition
-            // If the sender is not in *any* partition, default to delivering to all internal replicas
-            partition = this.twinsTransport.getDefaultPartitions()
-                    .stream()
-                    .filter(p -> p.contains(sender))
-                    .findFirst()
-                    .orElse(this.getInternalIds()); // default to all internal replicas handling the message
+        // Messages without round info (e.g. client requests) are not partitioned:
+        // deliver to all twin instances.
+        if (!(message instanceof MessageWithByzzFuzzRoundInfo roundInfo)) {
+            return new ArrayList<>(replicas);
         }
 
-        if (partition == null) {
-            throw new IllegalArgumentException("Sender not found in any partition: " + sender);
+        long round = roundInfo.getRound();
+        List<String> senderAddresses = this.twinsTransport.getEffectiveAddresses(sender);
+
+        // Collect the addresses reachable from the sender in this round's partition.
+        Set<String> reachable = new HashSet<>();
+        boolean senderPartitioned = false;
+        for (String senderAddress : senderAddresses) {
+            List<String> partition = this.twinsTransport.getPartitionContaining(senderAddress, round);
+            if (partition != null) {
+                senderPartitioned = true;
+                reachable.addAll(partition);
+            }
         }
 
-        return partition.stream()
-                .filter(this::isInternalId)
+        // Sender outside the partition universe (e.g. a client): deliver to all.
+        if (!senderPartitioned) {
+            return new ArrayList<>(replicas);
+        }
+
+        // Deliver only to this twin's instances that share a partition with the sender.
+        return getInternalIds().stream()
+                .filter(reachable::contains)
                 .map(this::getInternalReplicaFromId)
                 .toList();
     }
@@ -164,7 +166,7 @@ public class TwinsReplica extends Replica {
     public void handleMessage(String sender, MessagePayload message) {
         List<Replica> internalReplicas = this.getInternalReplicasHandlingMessage(sender, message);
 
-        // deliver to all sub-replicas
+        // deliver to all sub-replicas in the sender's partition
         for (Replica internalReplica : internalReplicas) {
             internalReplica.handleMessage(sender, message);
         }

--- a/simulator/src/main/java/byzzbench/simulator/exploration_strategy/twins/TwinsTransport.java
+++ b/simulator/src/main/java/byzzbench/simulator/exploration_strategy/twins/TwinsTransport.java
@@ -1,5 +1,6 @@
 package byzzbench.simulator.exploration_strategy.twins;
 
+import byzzbench.simulator.Scenario;
 import byzzbench.simulator.exploration_strategy.byzzfuzz.MessageWithByzzFuzzRoundInfo;
 import byzzbench.simulator.nodes.Node;
 import byzzbench.simulator.nodes.Replica;
@@ -13,50 +14,97 @@ import java.time.Duration;
 import java.util.*;
 
 /**
- * A transport layer that is used by the {@link TwinsReplica} to route messages
- * internally between the twin replica instances.
+ * A transport layer that enforces a <b>single, global, per-round network
+ * partition</b> shared by every replica in the scenario, as described in
+ * "Twins: BFT Systems Made Robust" by Shehar Bano, Alberto Sonnino, Andrey
+ * Chursin, Dmitri Perelman, Zekun Li, Avery Ching and Dahlia Malkhi.
+ * https://drops.dagstuhl.de/entities/document/10.4230/LIPIcs.OPODIS.2021.7
+ * <p>
+ * The partitions are a property of the <i>scenario</i>, not of an individual
+ * twin: a message between two nodes is delivered for a given round only if both
+ * the (effective) sender address and the (effective) recipient address belong
+ * to the same partition of that round. The same schedule governs honest&harr;honest,
+ * honest&harr;twin and twin&harr;honest links alike.
+ * <p>
+ * Twin instances are represented in the partition by their internal addresses
+ * ({@code <id>:0}, {@code <id>:1}, ...) while honest replicas are represented by
+ * their plain id. This lets a node and its twin be placed in different
+ * partitions (account-address filtering, not public-key filtering), which is
+ * what enables equivocation/amnesia/lost-state behaviors.
  */
 @Log
 public class TwinsTransport extends Transport implements Serializable {
     /**
-     * Partitions to use for the replicas if another partition is not specified.
+     * The single global per-round partition schedule shared by all nodes.
+     * Maps a round number to the list of partitions in effect for that round.
+     */
+    @Getter
+    private final NavigableMap<Long, List<List<String>>> roundPartitions = new TreeMap<>();
+
+    /**
+     * Partition to use when a message carries no round information: a single
+     * partition containing the whole universe (i.e. fully connected).
      */
     @Getter
     private final List<List<String>> defaultPartitions;
 
     /**
-     * Scheduled partitions to use for each round.
+     * Effective (partition-universe) address of each replica instance. Honest
+     * replicas map to their id; twin instances map to their internal id.
      */
-    @Getter
-    private final Map<Long, List<List<String>>> roundPartitions = new TreeMap<>();
-
-    @Getter
-    private final Map<String, List<Long>> queuedTimeouts = new TreeMap<>();
+    private final Map<Replica, String> senderAddress = new HashMap<>();
 
     /**
-     * The Twins Replica using this transport.
+     * Maps an external recipient id to the effective addresses it expands to. An
+     * honest replica maps to a singleton of its id; a twin replica maps to the
+     * internal ids of all its instances.
      */
-    private final TwinsReplica twinsReplica;
+    private final Map<String, List<String>> recipientAddresses = new HashMap<>();
 
     /**
-     * Create a new Twins transport layer for the given Twins replica.
+     * Ids of the consensus replicas. Used to let client traffic bypass
+     * inter-replica partitioning.
+     */
+    private final Set<String> replicaIds = new HashSet<>();
+
+    /**
+     * Queued timeout event ids, tracked per effective address so that a twin
+     * instance's timeouts can be cleared independently of its sibling (which
+     * shares the same external id).
+     */
+    @Getter
+    private final Map<String, List<Long>> queuedTimeouts = new HashMap<>();
+
+    /**
+     * Create the global Twins transport.
      *
-     * @param twinsReplica the Twins replica
+     * @param scenario        the scenario
+     * @param roundPartitions the single, global per-round partition schedule
+     * @param universe        the partition universe (all effective addresses)
      */
-    public TwinsTransport(TwinsReplica twinsReplica) {
-        super(twinsReplica.getScenario());
-        this.twinsReplica = twinsReplica;
+    public TwinsTransport(Scenario scenario, Map<Long, List<List<String>>> roundPartitions, List<String> universe) {
+        super(scenario);
+        this.roundPartitions.putAll(roundPartitions);
+        this.defaultPartitions = List.of(new ArrayList<>(universe));
 
-        // By default, both internal replicas will be connected to the network.
-        List<String> singlePartition = new ArrayList<>();
-        singlePartition.addAll(twinsReplica.getNodeIds().stream().filter(id -> !id.equals(twinsReplica.getId())).toList());
-        singlePartition.addAll(twinsReplica.getInternalIds());
-        this.defaultPartitions = List.of(singlePartition);
+        // Build the address book for every consensus replica in the scenario.
+        for (Replica replica : scenario.getReplicas().values()) {
+            this.replicaIds.add(replica.getId());
+            if (replica instanceof TwinsReplica twin) {
+                this.recipientAddresses.put(twin.getId(), twin.getInternalIds());
+                for (Replica instance : twin.getReplicas()) {
+                    this.senderAddress.put(instance, twin.getInternalId(instance));
+                }
+            } else {
+                this.recipientAddresses.put(replica.getId(), List.of(replica.getId()));
+                this.senderAddress.put(replica, replica.getId());
+            }
+        }
     }
 
-
     /**
-     * Get the partitions to use for a given round number
+     * Get the partitions in effect for the given round (fully connected if the
+     * round has no scheduled partition, e.g. when over-running past numRounds).
      *
      * @param roundNumber the round number
      * @return the partitions to use
@@ -66,141 +114,140 @@ public class TwinsTransport extends Transport implements Serializable {
     }
 
     /**
-     * Get the partition that the given replica ID is in for the given round number.
+     * Get the effective partition-universe addresses an external id expands to.
      *
-     * @param replicaId   the replica ID
-     * @param roundNumber the round number
-     * @return the partition
+     * @param externalId the external (network-visible) id
+     * @return the effective addresses
      */
-    public List<String> getReplicaRoundPartition(String replicaId, long roundNumber) {
-        List<List<String>> partition = getRoundPartition(roundNumber);
-
-        for (List<String> replicaPartition : partition) {
-            if (replicaPartition.contains(replicaId)) {
-                return replicaPartition;
-            }
-        }
-
-        throw new IllegalArgumentException("Replica ID not found in any partition: " + replicaId);
+    public List<String> getEffectiveAddresses(String externalId) {
+        return this.recipientAddresses.getOrDefault(externalId, List.of(externalId));
     }
 
     /**
-     * Check if two nodes can communicate with each other, given a specific partition.
+     * Get the partition (for the given round) that contains the given address,
+     * or {@code null} if the address is not part of any partition.
      *
-     * @param sender    the sender node (internal ID of internal "twin" replica)
-     * @param recipient the recipient node
-     * @return true if the two nodes can communicate
+     * @param address the effective address
+     * @param round   the round number
+     * @return the partition containing the address, or null
      */
-    public boolean canSendMessage(String sender, String recipient, MessagePayload message) {
-        List<String> partition;
-        if (message instanceof MessageWithByzzFuzzRoundInfo messageWithByzzFuzzRoundInfo) {
-            // If the message has a round number, use the partition for that round
-            partition = getReplicaRoundPartition(sender, messageWithByzzFuzzRoundInfo.getRound());
-        } else {
-            // Default to the default partition
-            partition = getDefaultPartitions()
-                    .stream()
-                    .filter(p -> p.contains(sender))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Sender not found in any partition: " + sender));
+    public List<String> getPartitionContaining(String address, long round) {
+        for (List<String> partition : getRoundPartition(round)) {
+            if (partition.contains(address)) {
+                return partition;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Get the effective partition-universe address of a sending node.
+     */
+    private String getEffectiveAddress(Node node) {
+        if (node instanceof Replica replica) {
+            return this.senderAddress.getOrDefault(replica, replica.getId());
+        }
+        return node.getId();
+    }
+
+    /**
+     * Decide whether a message from {@code sender} can reach {@code recipient}
+     * under the global partition for the message's round.
+     *
+     * @param sender    the sending node
+     * @param recipient the external recipient id
+     * @param message   the message being sent
+     * @return true if the message can be delivered
+     */
+    public boolean canSendMessage(Node sender, String recipient, MessagePayload message) {
+        // Client (or otherwise non-consensus) traffic is never partitioned.
+        if (!this.replicaIds.contains(recipient)) {
+            return true;
         }
 
-        if (partition == null) {
-            throw new IllegalArgumentException("Sender not found in any partition: " + sender);
+        // Without round information we cannot place the message in a round, so it
+        // is not subject to round-based partitioning (treated as fully connected).
+        if (!(message instanceof MessageWithByzzFuzzRoundInfo roundInfo)) {
+            return true;
         }
 
-        return partition.contains(recipient);
+        long round = roundInfo.getRound();
+        String senderAddr = getEffectiveAddress(sender);
+        List<String> senderPartition = getPartitionContaining(senderAddr, round);
+
+        // Sender outside the partition universe: fail open.
+        if (senderPartition == null) {
+            return true;
+        }
+
+        // Deliverable iff some instance of the recipient shares the partition.
+        return getEffectiveAddresses(recipient).stream().anyMatch(senderPartition::contains);
     }
 
     @Override
     public synchronized void sendMessage(Node sender, MessagePayload message, String recipient) {
-        // Sanity check
-        if (!(sender instanceof Replica replicaSender)) {
-            throw new IllegalArgumentException("Sender must be a Replica");
-        }
-
-        String internalId = this.twinsReplica.getInternalId(replicaSender);
-
-        if (canSendMessage(internalId, recipient, message)) {
+        if (canSendMessage(sender, recipient, message)) {
             this.getScenario().getTransport().sendMessage(sender, message, recipient);
         } else {
-            log.info("Message from " + internalId + " to " + recipient + " blocked by partitioning");
+            log.info("Message from " + getEffectiveAddress(sender) + " to " + recipient + " blocked by partitioning");
         }
     }
 
     @Override
     public synchronized void multicast(Node sender, SortedSet<String> recipients, MessagePayload payload) {
-        // Sanity check
-        if (!(sender instanceof Replica replicaSender)) {
-            throw new IllegalArgumentException("Sender must be a Replica");
+        SortedSet<String> allowed = new TreeSet<>();
+        SortedSet<String> dropped = new TreeSet<>();
+        for (String recipient : recipients) {
+            if (canSendMessage(sender, recipient, payload)) {
+                allowed.add(recipient);
+            } else {
+                dropped.add(recipient);
+            }
         }
 
-        String internalId = this.twinsReplica.getInternalId(replicaSender);
-
-        // Send the message to the available recipients, if any
-        List<String> availableRecipients = recipients.stream()
-                .filter(recipient -> canSendMessage(internalId, recipient, payload))
-                .toList();
-        if (!availableRecipients.isEmpty()) {
-            this.getScenario().getTransport().multicast(sender, new TreeSet<>(availableRecipients), payload);
+        if (!allowed.isEmpty()) {
+            this.getScenario().getTransport().multicast(sender, allowed, payload);
         }
-
-        // Log the dropped recipients, if any
-        List<String> droppedRecipients = recipients.stream()
-                .filter(recipient -> !canSendMessage(internalId, recipient, payload))
-                .toList();
-        if (!droppedRecipients.isEmpty()) {
-            log.info("Message from " + internalId + " to " + droppedRecipients + " blocked by partitioning");
+        if (!dropped.isEmpty()) {
+            log.info("Message from " + getEffectiveAddress(sender) + " to " + dropped + " blocked by partitioning");
         }
     }
 
     @Override
     public synchronized void sendClientResponse(Node sender, MessagePayload response, String recipient) {
-        // Sanity check
-        if (!(sender instanceof Replica replicaSender)) {
-            throw new IllegalArgumentException("Sender must be a Replica");
-        }
-
-        String internalId = this.twinsReplica.getInternalId(replicaSender);
-
-        if (canSendMessage(internalId, recipient, response)) {
-            this.getScenario().getTransport().sendMessage(sender, response, recipient);
-        } else {
-            log.info("Message from " + internalId + " to " + recipient + " blocked by partitioning");
-        }
+        // Client responses are not subject to inter-replica partitioning.
+        this.getScenario().getTransport().sendMessage(sender, response, recipient);
     }
 
     @Override
     public synchronized long setTimeout(Node node, Runnable runnable, Duration timeout, String description) {
         long eventId = this.getScenario().getTransport().setTimeout(node, runnable, timeout, description);
-
         this.queuedTimeouts
-                .computeIfAbsent(node.getId(), k -> new ArrayList<>())
+                .computeIfAbsent(getEffectiveAddress(node), k -> new ArrayList<>())
                 .add(eventId);
-
         return eventId;
     }
 
     @Override
     public synchronized void clearTimeout(Node node, long eventId) {
         this.getScenario().getTransport().clearTimeout(node, eventId);
-
         this.queuedTimeouts
-                .computeIfAbsent(node.getId(), k -> new ArrayList<>())
-                .remove(eventId);
+                .getOrDefault(getEffectiveAddress(node), Collections.emptyList())
+                .remove(Long.valueOf(eventId));
     }
 
     @Override
     public synchronized void clearNodeTimeouts(Node node) {
-        if (!(node instanceof Replica replica)) {
-            throw new IllegalArgumentException("Node must be a Replica");
+        String address = getEffectiveAddress(node);
+        List<Long> timeouts = this.queuedTimeouts.getOrDefault(address, Collections.emptyList());
+
+        for (Long eventId : new ArrayList<>(timeouts)) {
+            try {
+                this.getScenario().getTransport().clearTimeout(node, eventId);
+            } catch (IllegalArgumentException e) {
+                // Timeout already fired or cleared; nothing to do.
+            }
         }
-
-        String internalId = this.twinsReplica.getInternalId(replica);
-
-        List<Long> replicaTimeouts = this.queuedTimeouts.getOrDefault(internalId, Collections.emptyList());
-
-        replicaTimeouts.forEach(eventId -> this.getScenario().getTransport().clearTimeout(node, eventId));
-        replicaTimeouts.clear();
+        timeouts.clear();
     }
 }

--- a/simulator/src/test/java/byzzbench/simulator/exploration_strategy/twins/TwinsExplorationStrategyTest.java
+++ b/simulator/src/test/java/byzzbench/simulator/exploration_strategy/twins/TwinsExplorationStrategyTest.java
@@ -1,0 +1,190 @@
+package byzzbench.simulator.exploration_strategy.twins;
+
+import byzzbench.simulator.Scenario;
+import byzzbench.simulator.domain.Campaign;
+import byzzbench.simulator.domain.ScenarioParameters;
+import byzzbench.simulator.domain.Schedule;
+import byzzbench.simulator.exploration_strategy.ExplorationStrategyParameters;
+import byzzbench.simulator.exploration_strategy.byzzfuzz.MessageWithByzzFuzzRoundInfo;
+import byzzbench.simulator.nodes.Replica;
+import byzzbench.simulator.protocols.pbft_java.PbftJavaScenario;
+import byzzbench.simulator.transport.MessagePayload;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the Twins exploration strategy installs a <b>single, global,
+ * per-round network partition</b> shared by every replica (rather than an
+ * independent, randomly-generated partition per twin), and that this partition
+ * is enforced on honest-to-honest links — not only on the twin's own links.
+ */
+@DisplayName("Twins: global per-round partitioning")
+class TwinsExplorationStrategyTest {
+
+    private static final int NUM_ROUNDS = 5;
+    private static final int NUM_TWINS = 2;
+
+    private Scenario scenario;
+    private TwinsTransport transport;
+    private String victimId;
+    private List<String> honestIds;
+
+    @BeforeEach
+    void setup() {
+        Schedule schedule = new Schedule(ScenarioParameters.builder()
+                .scenarioId("pbft-java")
+                .randomSeed(0L)
+                .numClients(1)
+                .numReplicas(4)
+                .build());
+
+        ExplorationStrategyParameters strategyParams = new ExplorationStrategyParameters();
+        strategyParams.setRandomSeed(0L);
+        strategyParams.getParams().put("numReplicas", "1");
+        strategyParams.getParams().put("numTwinsPerReplica", String.valueOf(NUM_TWINS));
+        strategyParams.getParams().put("numRounds", String.valueOf(NUM_ROUNDS));
+
+        Campaign campaign = new Campaign();
+        campaign.setExplorationStrategyParameters(strategyParams);
+        schedule.setCampaign(campaign);
+
+        scenario = new PbftJavaScenario(schedule);
+
+        // Ensure there is a compromised replica for the strategy to twin.
+        scenario.markReplicaFaulty(scenario.getReplicas().firstKey());
+
+        TwinsExplorationStrategy strategy = new TwinsExplorationStrategy();
+        strategy.initializeScenario(scenario);
+
+        // Discover which replica was turned into a twin.
+        victimId = scenario.getReplicas().values().stream()
+                .filter(TwinsReplica.class::isInstance)
+                .map(Replica::getId)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no TwinsReplica was created"));
+        honestIds = scenario.getReplicas().keySet().stream()
+                .filter(id -> !id.equals(victimId))
+                .toList();
+
+        transport = (TwinsTransport) scenario.getReplicas().get(honestIds.get(0)).getTransport();
+    }
+
+    @Test
+    @DisplayName("the compromised replica is replaced by a multiplexing TwinsReplica")
+    void victimBecomesTwinsReplica() {
+        assertTrue(scenario.getNodes().get(victimId) instanceof TwinsReplica);
+    }
+
+    @Test
+    @DisplayName("all replicas (honest and twin instances) share ONE global partition schedule")
+    void allReplicasShareOneGlobalTransport() {
+        // every honest replica uses the same shared transport object
+        for (String id : honestIds) {
+            assertSame(transport, scenario.getReplicas().get(id).getTransport(),
+                    "honest replica " + id + " should use the shared global Twins transport");
+        }
+
+        // the twin wrapper and all of its internal instances use the same transport
+        TwinsReplica twin = (TwinsReplica) scenario.getNodes().get(victimId);
+        assertSame(transport, twin.getTransport());
+        for (Replica instance : twin.getReplicas()) {
+            assertSame(transport, instance.getTransport(),
+                    "twin instance should use the shared global Twins transport");
+        }
+
+        // exactly one schedule, covering numRounds rounds
+        assertEquals(NUM_ROUNDS, transport.getRoundPartitions().size());
+    }
+
+    @Test
+    @DisplayName("honest-to-honest delivery obeys the global partition (and is cut across partitions)")
+    void honestToHonestRespectsPartitions() {
+        int blocked = 0;
+        for (long round = 0; round < NUM_ROUNDS; round++) {
+            MessagePayload msg = new RoundMessage(round);
+            for (String from : honestIds) {
+                Replica sender = scenario.getReplicas().get(from);
+                List<String> senderPartition = transport.getPartitionContaining(from, round);
+                assertNotNull(senderPartition, from + " must belong to some partition");
+                for (String to : honestIds) {
+                    if (from.equals(to)) {
+                        continue;
+                    }
+                    boolean samePartition = senderPartition.contains(to);
+                    boolean canSend = transport.canSendMessage(sender, to, msg);
+                    assertEquals(samePartition, canSend,
+                            "round " + round + ": " + from + " -> " + to
+                                    + " delivery must match partition membership");
+                    if (!canSend) {
+                        blocked++;
+                    }
+                }
+            }
+        }
+        // The whole point of the fix: the global partition actually cuts some
+        // honest-to-honest links (previously they were never partitioned).
+        assertTrue(blocked > 0,
+                "expected the global partition to block some honest-to-honest messages");
+    }
+
+    @Test
+    @DisplayName("a twin can be split across partitions, so only the co-located instance handles a message")
+    void twinInstancesCanBeSplit() {
+        TwinsReplica twin = (TwinsReplica) scenario.getNodes().get(victimId);
+        List<String> internalIds = twin.getInternalIds();
+
+        // find a round where the twin's two instances are in different partitions
+        long splitRound = -1;
+        for (long round = 0; round < NUM_ROUNDS; round++) {
+            List<String> p0 = transport.getPartitionContaining(internalIds.get(0), round);
+            if (p0 != null && !p0.contains(internalIds.get(1))) {
+                splitRound = round;
+                break;
+            }
+        }
+        assertTrue(splitRound >= 0, "expected at least one round where the twin is split across partitions");
+
+        // a round message from an honest node must be handled only by the twin
+        // instance(s) that share that honest node's partition
+        String honest = honestIds.get(0);
+        List<String> honestPartition = transport.getPartitionContaining(honest, splitRound);
+        assertNotNull(honestPartition);
+        long expected = internalIds.stream().filter(honestPartition::contains).count();
+
+        List<Replica> handlers = twin.getInternalReplicasHandlingMessage(honest, new RoundMessage(splitRound));
+        assertEquals(expected, handlers.size(),
+                "only twin instances in the sender's partition should handle the message");
+    }
+
+    /** A minimal message that carries a round number (as ByzzFuzz/Twins expect). */
+    private static class RoundMessage extends MessagePayload implements MessageWithByzzFuzzRoundInfo {
+        private final long round;
+
+        RoundMessage(long round) {
+            this.round = round;
+        }
+
+        @Override
+        public String getType() {
+            return "TEST_ROUND_MESSAGE";
+        }
+
+        @Override
+        public long getViewNumber() {
+            return round;
+        }
+
+        @Override
+        public long getRound() {
+            return round;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The Twins exploration strategy did not match the network-partition model from *"Twins: BFT Systems Made Robust"* (Bano et al.). Previously each `TwinsReplica` created its **own** `TwinsTransport` with its **own** independently randomized round-partitions, and that transport only filtered the twin's own links. So the partition was:

- **per-twin**, not a single global schedule, and
- **never applied to honest↔honest traffic** (honest replicas kept using the base transport).

In the paper, the partition is a property of the *scenario*: one global per-round partition applied to **all** nodes — two nodes communicate in a round iff they're in the same partition.

## What changed

- **`TwinsExplorationStrategy`** — after creating the twins, builds the global partition **universe** (honest replicas by id; twin instances by their internal addresses `id:0`/`id:1`), generates **one** per-round schedule (sampled from the Stirling 1/2/3-part partitions using the scenario's seeded RNG), constructs a single shared `TwinsTransport`, and wires **every** replica to it — honest replicas, twin wrappers, and internal instances.
- **`TwinsTransport`** — now a single global transport. `canSendMessage` enforces the schedule on **all** links (sender and recipient must share the round's partition). Twin instances resolve to their internal addresses so a node and its twin can still be split (equivocation/amnesia preserved); honest replicas resolve to their id. Client traffic and round-less messages bypass partitioning; per-instance timeout tracking is keyed by effective address (fixing a latent set/clear key mismatch).
- **`TwinsReplica`** — no longer creates a transport or partitions; receives the shared transport and routes an inbound message only to the instance(s) co-located with the sender in that round's partition.

## Tests

New `TwinsExplorationStrategyTest` (PBFT-based) verifies:
- every replica (honest + twin instances) shares **one** transport/schedule;
- honest→honest delivery **obeys** the global partition and is **cut** across partitions (the core fix);
- a twin can be **split** across partitions, so only the co-located instance handles a message.

Full module suite: **103 tests, 0 failures**.

## Out of scope (follow-ups)

- The schedule is still **randomly sampled** per round (now as one coherent global schedule) rather than the paper's *systematic* Step-2/3 enumeration.
- Twins still can't instantiate on **Fast-HotStuff** (no `cloneReplica`, no round-tagged messages), which is why the test uses PBFT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
